### PR TITLE
Update documentation to reflect new package

### DIFF
--- a/CONTRIBUTION_GUIDE.md
+++ b/CONTRIBUTION_GUIDE.md
@@ -47,7 +47,7 @@ export function yourLegoBrick() {
 
 ```svelte
 <script lang="ts">
-import { yourLegoBrick } from "svelte-legos";
+import { yourLegoBrick } from "@sveltelegos-blue/svelte-legos";
 
 const beingUsed = yourLegoBrick();
 </script>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Collection of essential Svelte Composition Utilities
 
 ```svelte
 <script lang="ts">
-import { counterStore } from "svelte-legos";
+import { counterStore } from "@sveltelegos-blue/svelte-legos";
 
 const { counter, inc, dec, set, reset } = counterStore();
 </script>
@@ -33,7 +33,7 @@ const { counter, inc, dec, set, reset } = counterStore();
 
 ```svelte
 <script lang="ts">
-import { clickOutsideAction } from "svelte-legos";
+import { clickOutsideAction } from "@sveltelegos-blue/svelte-legos";
 
 let hidden = false;
 

--- a/src/lib/actions/alertAction/usage.txt
+++ b/src/lib/actions/alertAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { alertAction } from "svelte-legos";
+import { alertAction } from "@sveltelegos-blue/svelte-legos";
 
 function onClose() {
   // handle on alert close

--- a/src/lib/actions/clickOutsideAction/usage.txt
+++ b/src/lib/actions/clickOutsideAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { clickOutsideAction } from "svelte-legos";
+import { clickOutsideAction } from "@sveltelegos-blue/svelte-legos";
 
 let hidden = false;
 

--- a/src/lib/actions/clickToCopyAction/usage.txt
+++ b/src/lib/actions/clickToCopyAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { clickToCopyAction } from "svelte-legos";
+import { clickToCopyAction } from "@sveltelegos-blue/svelte-legos";
 
 function handleCopyDone() {
   // handle copy done here

--- a/src/lib/actions/confettiAction/usage.txt
+++ b/src/lib/actions/confettiAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { confettiAction } from "svelte-legos";
+import { confettiAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <button

--- a/src/lib/actions/debounceClickAction/usage.txt
+++ b/src/lib/actions/debounceClickAction/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { debounceClickAction } from "svelte-legos";
+  import { debounceClickAction } from "@sveltelegos-blue/svelte-legos";
 
   function onClick() {
     // main click

--- a/src/lib/actions/documentTitleAction/usage.txt
+++ b/src/lib/actions/documentTitleAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { documentTitleAction } from "svelte-legos";
+  import { documentTitleAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <input use:documentTitleAction />

--- a/src/lib/actions/draggableAction/usage.txt
+++ b/src/lib/actions/draggableAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { draggableAction } from "svelte-legos";
+import { draggableAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <div class="box" use:draggableAction />

--- a/src/lib/actions/dropAction/usage.txt
+++ b/src/lib/actions/dropAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { dropAction } from "svelte-legos";;
+import { dropAction } from "@sveltelegos-blue/svelte-legos";;
 
 let filesData = [];
 

--- a/src/lib/actions/eyeDropperAction/usage.txt
+++ b/src/lib/actions/eyeDropperAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { eyeDropperAction } from "svelte-legos";
+  import { eyeDropperAction } from "@sveltelegos-blue/svelte-legos";
   let color = '';
 </script>
 

--- a/src/lib/actions/focusAction/usage.txt
+++ b/src/lib/actions/focusAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { focusAction } from "svelte-legos";
+  import { focusAction } from "@sveltelegos-blue/svelte-legos";
   let isFocused = true;
 </script>
 

--- a/src/lib/actions/fullScreenAction/usage.txt
+++ b/src/lib/actions/fullScreenAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { fullScreenAction } from "svelte-legos";
+  import { fullScreenAction } from "@sveltelegos-blue/svelte-legos";
   let ref;
 </script>
 

--- a/src/lib/actions/hotKeyAction/usage.txt
+++ b/src/lib/actions/hotKeyAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { hotKeyAction } from "svelte-legos";
+  import { hotKeyAction } from "@sveltelegos-blue/svelte-legos";
 
   let timesClicked = 0;
   let timesClickedCallback = 0;

--- a/src/lib/actions/hoverAction/usage.txt
+++ b/src/lib/actions/hoverAction/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { hoverAction } from "svelte-legos";
+import { hoverAction } from "@sveltelegos-blue/svelte-legos";
 
 function handleHover(e: CustomEvent<{ hover: boolean }>) {
   alert(`Box hovered: ${e.detail.hover}`);

--- a/src/lib/actions/infiniteScrollAction/usage.txt
+++ b/src/lib/actions/infiniteScrollAction/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { infiniteScrollAction } from "svelte-legos";
+import { infiniteScrollAction } from "@sveltelegos-blue/svelte-legos";
 
 let isLoading = false;
 

--- a/src/lib/actions/lazyLoadImageAction/usage.txt
+++ b/src/lib/actions/lazyLoadImageAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { lazyLoadImageAction } from "svelte-legos";
+import { lazyLoadImageAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <img use:lazyLoadImageAction data-src="https://source.unsplash.com/8n7ipHhI8CI" />

--- a/src/lib/actions/loadingAction/usage.txt
+++ b/src/lib/actions/loadingAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { loadingAction } from "svelte-legos";
+import { loadingAction } from "@sveltelegos-blue/svelte-legos";
 
 let loading = false;
 </script>

--- a/src/lib/actions/longPressAction/usage.txt
+++ b/src/lib/actions/longPressAction/usage.txt
@@ -1,6 +1,6 @@
 <script>
 
-import { longPressAction } from "svelte-legos";
+import { longPressAction } from "@sveltelegos-blue/svelte-legos";
 
 let pressed = false;
 let duration = 2000;

--- a/src/lib/actions/messageAction/usage.txt
+++ b/src/lib/actions/messageAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { messageAction } from "svelte-legos";
+import { messageAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <button

--- a/src/lib/actions/notifyAction/usage.txt
+++ b/src/lib/actions/notifyAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { notifyAction } from "svelte-legos";
+import { notifyAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <button

--- a/src/lib/actions/portalAction/usage.txt
+++ b/src/lib/actions/portalAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { portalAction } from "svelte-legos";
+  import { portalAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 // This action takes only one optional parameter: a target

--- a/src/lib/actions/resizableAction/usage.txt
+++ b/src/lib/actions/resizableAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { resizableAction } from "svelte-legos";
+import { resizableAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <div class="box" use:resizableAction />

--- a/src/lib/actions/scrollToBottomAction/usage.txt
+++ b/src/lib/actions/scrollToBottomAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { scrollToBottomAction } from "svelte-legos";
+import { scrollToBottomAction } from "@sveltelegos-blue/svelte-legos";
 
 // messages data
 let messages = [];

--- a/src/lib/actions/sortableTableAction/usage.txt
+++ b/src/lib/actions/sortableTableAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { sortableTableAction } from "svelte-legos";
+import { sortableTableAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <table use:sortableTableAction>

--- a/src/lib/actions/textareaAutosizeAction/usage.txt
+++ b/src/lib/actions/textareaAutosizeAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-  import { textareaAutosizeAction } from "svelte-legos";
+  import { textareaAutosizeAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <textarea use:textareaAutosizeAction />

--- a/src/lib/actions/tooltipAction/usage.txt
+++ b/src/lib/actions/tooltipAction/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { tooltipAction } from "svelte-legos";
+import { tooltipAction } from "@sveltelegos-blue/svelte-legos";
 </script>
 
 <div use:tooltipAction={"Tooltip Content"}>

--- a/src/lib/derivatives/first/usage.txt
+++ b/src/lib/derivatives/first/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { first } from "svelte-legos";
+import { first } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const data = writable([

--- a/src/lib/derivatives/pick/usage.txt
+++ b/src/lib/derivatives/pick/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { pick } from "svelte-legos";
+import { pick } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const data = writable({

--- a/src/lib/derivatives/pickArray/usage.txt
+++ b/src/lib/derivatives/pickArray/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { pick } from "svelte-legos";
+import { pick } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const data = writable([

--- a/src/lib/derivatives/sizeOf/usage.txt
+++ b/src/lib/derivatives/sizeOf/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { sizeOf } from "svelte-legos";
+import { sizeOf } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const list = writable([1, 2, 3, 4, 5, 6]);

--- a/src/lib/derivatives/sort/usage.txt
+++ b/src/lib/derivatives/sort/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { sort } from "svelte-legos";
+import { sort } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const data = writable([1, 5, 6, 2, 9, 6, 7, 8]);

--- a/src/lib/derivatives/toNumber/usage.txt
+++ b/src/lib/derivatives/toNumber/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { toNumber } from "svelte-legos";
+import { toNumber } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const str = writable("1.0");

--- a/src/lib/middlewares/history/usage.txt
+++ b/src/lib/middlewares/history/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { history } from "svelte-legos";
+import { history } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = history(writable(0));

--- a/src/lib/stores/counterStore/usage.txt
+++ b/src/lib/stores/counterStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { counterStore } from "svelte-legos";
+import { counterStore } from "@sveltelegos-blue/svelte-legos";
 
 const { counter, inc, dec, set, reset } = counterStore();
 </script>

--- a/src/lib/stores/documentVisibilityStore/usage.txt
+++ b/src/lib/stores/documentVisibilityStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { documentVisibilityStore } from "svelte-legos";
+import { documentVisibilityStore } from "@sveltelegos-blue/svelte-legos";
 
 const visibility = documentVisibilityStore();
 

--- a/src/lib/stores/elementSizeStore/usage.txt
+++ b/src/lib/stores/elementSizeStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { elementSizeStore } from "svelte-legos";
+import { elementSizeStore } from "@sveltelegos-blue/svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/stores/elementVisibilityStore/usage.txt
+++ b/src/lib/stores/elementVisibilityStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { elementVisibilityStore } from "svelte-legos";
+import { elementVisibilityStore } from "@sveltelegos-blue/svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/stores/geolocationStore/usage.txt
+++ b/src/lib/stores/geolocationStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { geolocationStore } from "svelte-legos";
+import { geolocationStore } from "@sveltelegos-blue/svelte-legos";
 
 const geolocation = geolocationStore({ watch: true });
 $: ({ status, position, error } = $geolocation)

--- a/src/lib/stores/hoverStore/usage.txt
+++ b/src/lib/stores/hoverStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { hoverStore } from "svelte-legos";
+import { hoverStore } from "@sveltelegos-blue/svelte-legos";
 
 let ref: HTMLDivElement | null = null;
 

--- a/src/lib/stores/intervalFnStore/usage.txt
+++ b/src/lib/stores/intervalFnStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { intervalFnStore } from "svelte-legos";
+import { intervalFnStore } from "@sveltelegos-blue/svelte-legos";
 
 const { pause, resume, isActive, changeIntervalTime } = intervalFnStore(() => {
   /* your function */

--- a/src/lib/stores/intervalStore/usage.txt
+++ b/src/lib/stores/intervalStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { intervalStore } from "svelte-legos";
+import { intervalStore } from "@sveltelegos-blue/svelte-legos";
 
 const counter = intervalStore(200);
 

--- a/src/lib/stores/messagesStore/usage.txt
+++ b/src/lib/stores/messagesStore/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { messagesStore } from "svelte-legos";
+import { messagesStore } from "@sveltelegos-blue/svelte-legos";
 
 function handleClick() {
   messagesStore("Here is your message");

--- a/src/lib/stores/rafFnStore/usage.txt
+++ b/src/lib/stores/rafFnStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { rafFnStore } from "svelte-legos";
+import { rafFnStore } from "@sveltelegos-blue/svelte-legos";
 
 let counter = 0;
 

--- a/src/lib/stores/resizeObserverStore/usage.txt
+++ b/src/lib/stores/resizeObserverStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { resizeObserverStore } from "svelte-legos";
+import { resizeObserverStore } from "@sveltelegos-blue/svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/stores/textSelectionStore/usage.txt
+++ b/src/lib/stores/textSelectionStore/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { textSelectionStore } from "svelte-legos";
+import { textSelectionStore } from "@sveltelegos-blue/svelte-legos";
 
 const selectionStore = textSelectionStore();
 

--- a/src/lib/stores/toggleStore/usage.txt
+++ b/src/lib/stores/toggleStore/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { toggleStore } from "svelte-legos";
+import { toggleStore } from "@sveltelegos-blue/svelte-legos";
 
 const { toggle, on, off, set, value } = toggleStore();
 

--- a/src/lib/transitions/roll/usage.txt
+++ b/src/lib/transitions/roll/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { roll } from "svelte-legos";
+import { roll } from "@sveltelegos-blue/svelte-legos";
 
 </script>
 

--- a/src/lib/transitions/slide/usage.txt
+++ b/src/lib/transitions/slide/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { slide } from "svelte-legos";
+import { slide } from "@sveltelegos-blue/svelte-legos";
 
 </script>
 

--- a/src/lib/transitions/swirl/usage.txt
+++ b/src/lib/transitions/swirl/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { swirl } from "svelte-legos";
+import { swirl } from "@sveltelegos-blue/svelte-legos";
 
 </script>
 

--- a/src/lib/utilities/battery/usage.txt
+++ b/src/lib/utilities/battery/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { battery } from "svelte-legos";
+import { battery } from "@sveltelegos-blue/svelte-legos";
 
 const info = battery();
 

--- a/src/lib/utilities/clipboard/usage.txt
+++ b/src/lib/utilities/clipboard/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { clipboard } from "svelte-legos";
+import { clipboard } from "@sveltelegos-blue/svelte-legos";
 
 let value = "";
 const board = clipboard();

--- a/src/lib/utilities/fetchWithTimeoutAndRetry/usage.txt
+++ b/src/lib/utilities/fetchWithTimeoutAndRetry/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { fetchWithTimeoutAndRetry } from "svelte-legos";
+import { fetchWithTimeoutAndRetry } from "@sveltelegos-blue/svelte-legos";
 
 function handleRetry() {
 	// handle retry if you want

--- a/src/lib/utilities/hasPermission/usage.txt
+++ b/src/lib/utilities/hasPermission/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { hasPermission } from "svelte-legos";
+import { hasPermission } from "@sveltelegos-blue/svelte-legos";
 
 const accelerometer = hasPermission("accelerometer");
 const accessibilityEvents = hasPermission("accessibility-events");

--- a/src/lib/utilities/mediaQuery/usage.txt
+++ b/src/lib/utilities/mediaQuery/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { mediaQuery } from "svelte-legos";
+import { mediaQuery } from "@sveltelegos-blue/svelte-legos";
 
 const isLargeScreen = mediaQuery("(min-width: 1024px)"); // $isLargeScreen => true | false
 const prefersDark = mediaQuery("(prefers-color-scheme: dark)");  // $prefersDark => true | false

--- a/src/lib/utilities/preferredColorScheme/usage.txt
+++ b/src/lib/utilities/preferredColorScheme/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { preferredColorScheme } from "svelte-legos";
+import { preferredColorScheme } from "@sveltelegos-blue/svelte-legos";
 
 const colorScheme = preferredColorScheme();
 

--- a/src/lib/utilities/preferredContrast/usage.txt
+++ b/src/lib/utilities/preferredContrast/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { preferredContrast } from "svelte-legos";
+import { preferredContrast } from "@sveltelegos-blue/svelte-legos";
 
 const contrast = preferredContrast();
 

--- a/src/lib/utilities/preferredDark/usage.txt
+++ b/src/lib/utilities/preferredDark/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { preferredDark } from "svelte-legos";
+import { preferredDark } from "@sveltelegos-blue/svelte-legos";
 
 const prefersDark = preferredDark();
 

--- a/src/lib/utilities/preferredLanguages/usage.txt
+++ b/src/lib/utilities/preferredLanguages/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { preferredLanguages } from "svelte-legos";
+import { preferredLanguages } from "@sveltelegos-blue/svelte-legos";
 
 const languages = preferredLanguages();
 

--- a/src/lib/utilities/preferredReduceMotion/usage.txt
+++ b/src/lib/utilities/preferredReduceMotion/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { preferredReduceMotion } from "svelte-legos";
+import { preferredReduceMotion } from "@sveltelegos-blue/svelte-legos";
 
 const motion = preferredReduceMotion();
 

--- a/src/lib/utilities/reduceable/usage.txt
+++ b/src/lib/utilities/reduceable/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { reduceable } from "svelte-legos";
+import { reduceable } from "@sveltelegos-blue/svelte-legos";
 
 function reducer(state: number, action: string) {
 	switch (action) {

--- a/src/lib/utilities/screenOrientation/usage.txt
+++ b/src/lib/utilities/screenOrientation/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { screenOrientation } from "svelte-legos";
+import { screenOrientation } from "@sveltelegos-blue/svelte-legos";
 
 const data = screenOrientation();
 $: ({ isSupported, orientation, angle } = $data);

--- a/src/lib/utilities/startViewTransition/usage.txt
+++ b/src/lib/utilities/startViewTransition/usage.txt
@@ -1,7 +1,7 @@
 <script lang="ts">
   // Root layout.svelte file
   
-  import { startViewTransition } from "svelte-legos";
+  import { startViewTransition } from "@sveltelegos-blue/svelte-legos";
 
   startViewTransition();
 

--- a/src/lib/watchers/pausableWatch/usage.txt
+++ b/src/lib/watchers/pausableWatch/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { pausableWatch } from "svelte-legos";
+import { pausableWatch } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const source = writable("");

--- a/src/lib/watchers/takeUntil/usage.txt
+++ b/src/lib/watchers/takeUntil/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { takeUntil } from "svelte-legos";
+import { takeUntil } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = writable(0);

--- a/src/lib/watchers/takeWhile/usage.txt
+++ b/src/lib/watchers/takeWhile/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { takeWhile } from "svelte-legos";
+import { takeWhile } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = writable(0);

--- a/src/lib/watchers/watch/usage.txt
+++ b/src/lib/watchers/watch/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { watch } from "svelte-legos";
+import { watch } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = writable(0);

--- a/src/lib/watchers/watchOnce/usage.txt
+++ b/src/lib/watchers/watchOnce/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { watchOnce } from "svelte-legos";
+import { watchOnce } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = writable(0);

--- a/src/lib/watchers/watchWithFilter/usage.txt
+++ b/src/lib/watchers/watchWithFilter/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { watchWithFilter } from "svelte-legos";
+import { watchWithFilter } from "@sveltelegos-blue/svelte-legos";
 import { writable } from "svelte/store";
 
 const counter = writable(0);


### PR DESCRIPTION
Updated docs to use "@sveltelegos-blue/svelte-legos" instead of "svelte-legos".

Would be nice if the npm package could be changed into something simpler such as "svelte-legos-blue".